### PR TITLE
Fix Canvas size

### DIFF
--- a/client/theia-ecore/sprotty-ecore/css/diagram.css
+++ b/client/theia-ecore/sprotty-ecore/css/diagram.css
@@ -12,9 +12,13 @@
     border-width: 1px;
     border-color: #bbb;
 }
+.sprotty {
+    height: 100%;
+}
 
 .sprotty-graph {
     font-size: 15pt;
+    height: 100%;
 }
 
 .sprotty-node {


### PR DESCRIPTION
Adjusts the css to allow the sprotty div and the enclosed SVG span 100 %
of the widget size. #7 
https://github.com/eclipsesource/graphical-lsp/pull/45