### PR TITLE
Improve CSS of Ecore Sprotty Editor

### DIFF
--- a/client/theia-ecore/sprotty-ecore/css/diagram.css
+++ b/client/theia-ecore/sprotty-ecore/css/diagram.css
@@ -19,20 +19,21 @@
 .sprotty-graph {
     font-size: 15pt;
     height: 100%;
+    background: #fff
 }
 
-.sprotty-node {
-    fill: #cdc;
-    stroke: #152;
-    stroke-width: 0;
+.ecore-node {
+    fill: #fffcdb;
+    stroke: black;
+    stroke-width: 1;
     font-weight: bold;
 }
 
-.sprotty-node.selected {
+.ecore-node.selected {
     stroke-width: 5;
 }
 
-.sprotty-node.mouseover:not(.selected) {
+.ecore-node.mouseover:not(.selected) {
     stroke-width: 3;
 }
 
@@ -40,13 +41,15 @@
     line-height: 3px;
     font-weight: normal;
     text-align: left;
+    stroke: #000;
+    stroke-width: 2px;
 }
 
 .sprotty-label {
     stroke-width: 0;
+    width: inherit;
     fill: #000;
     font-weight: inherit;
-    text-align: inherit;
     font-size: 100%;
 }
 
@@ -55,12 +58,12 @@
 }
 
 .sprotty-icon {
-    fill: #153;
+    fill: #debe5b;
     stroke-width: 0;
 }
 
 .sprotty-label.icon {
-    fill: #fff;
+    fill: black;
 }
 
 .sprotty-button {
@@ -68,43 +71,33 @@
     stroke-width: 0;
 }
 
-.sprotty-edge {
+.ecore-edge {
     fill: none;
-    stroke: #488;
+    stroke: black;
     stroke-width: 2px;
 }
-.sprotty-edge.composition, .sprotty-edge.inheritance  {
-    fill: #fff;
-}
-.sprotty-edge.aggregation {
-    fill: #fff;
-}
 
-.sprotty-edge.selected {
-    stroke: #844;
-    stroke-width: 4px;
-}
 
-.sprotty-edge.mouseover:not(.selected) {
+.ecore-edge.mouseover:not(.selected) {
     stroke-width: 3px;
 }
 
-.sprotty-edge > .sprotty-routing-handle {
+.ecore-edge > .sprotty-routing-handle {
     r: 7px;
     fill: #884;
     stroke: none;
     z-index: 1000;
 }
 
-.sprotty-edge > .sprotty-routing-handle[data-kind='line'] {
+.ecore-edge > .sprotty-routing-handle[data-kind='line'] {
     opacity: 0.35;
 }
 
-.sprotty-edge > .sprotty-routing-handle.selected {
+.ecore-edge > .sprotty-routing-handle.selected {
     fill: #66a;
 }
 
-.sprotty-edge > .sprotty-routing-handle.mouseover {
+.ecore-edge > .sprotty-routing-handle.mouseover {
     stroke: #112;
     stroke-width: 1;
 }
@@ -125,3 +118,23 @@
 .sprotty-popup-body > p {
     margin-bottom: 2px;
 }
+.ecore-edge.inheritance  {
+    stroke: #888888;
+}
+.ecore-edge.aggregation .ecore-edge.composition {
+    stroke: black;
+}
+
+.ecore-edge.selected {
+    stroke: #844;
+    stroke-width: 4px;
+}
+.ecore-node.abstract {
+    fill: #ededed;
+}
+
+.ecore-node.enum {
+    fill: #e7f2da;
+}
+
+

--- a/client/theia-ecore/sprotty-ecore/package.json
+++ b/client/theia-ecore/sprotty-ecore/package.json
@@ -10,7 +10,7 @@
     "diagram"
   ],
   "dependencies": {
-    "glsp-sprotty": "latest"
+    "glsp-sprotty": "0.1.0-next.8f55d9d9"
   },
   "devDependencies": {
     "css-loader": "^1.0.1",

--- a/client/theia-ecore/sprotty-ecore/src/di.config.ts
+++ b/client/theia-ecore/sprotty-ecore/src/di.config.ts
@@ -42,7 +42,7 @@ import {
     LocalModelSource 
 } from "glsp-sprotty/lib";
 import { Container, ContainerModule } from "inversify";
-import { ClassNode, Icon, Link } from "./model";
+import { ClassNode, Icon, Link, EdgeWithMultiplicty } from "./model";
 import { AggregationEdgeView, ArrowEdgeView, ClassNodeView, CompositionEdgeView, IconView, InheritanceEdgeView, LinkView } from "./views";
 
 export default (containerId: string) => {
@@ -66,8 +66,8 @@ export default (containerId: string) => {
         configureModelElement(context, 'volatile-routing-point', SRoutingHandle, SRoutingHandleView);
         configureModelElement(context, 'edge:association', SEdge, ArrowEdgeView)
         configureModelElement(context, 'edge:inheritance', SEdge, InheritanceEdgeView)
-        configureModelElement(context, 'edge:aggregation', SEdge, AggregationEdgeView)
-        configureModelElement(context, 'edge:composition', SEdge, CompositionEdgeView)
+        configureModelElement(context, 'edge:aggregation', EdgeWithMultiplicty, AggregationEdgeView)
+        configureModelElement(context, 'edge:composition', EdgeWithMultiplicty, CompositionEdgeView)
         configureModelElement(context, 'link', Link, LinkView)
         configureViewerOptions(context, {
             needsClientLayout: true,

--- a/client/theia-ecore/sprotty-ecore/src/views.tsx
+++ b/client/theia-ecore/sprotty-ecore/src/views.tsx
@@ -8,7 +8,7 @@
 /** @jsx svg */
 import { svg }  from 'snabbdom-jsx';
 
-import { RenderingContext, RectangularNodeView, IView, PolylineEdgeView, SEdge, Point, toDegrees, SLabelView } from "glsp-sprotty/lib";
+import { RenderingContext, RectangularNodeView, IView, PolylineEdgeView, SEdge, Point, toDegrees, SLabelView} from "glsp-sprotty/lib";
 import { VNode } from "snabbdom/vnode";
 import { Icon, ClassNode, EdgeWithMultiplicty, Link } from './model';
 
@@ -16,7 +16,7 @@ export class ClassNodeView extends RectangularNodeView {
     render(node: ClassNode, context: RenderingContext): VNode {
         return <g class-node={true}>
             <rect class-sprotty-node={true} class-selected={node.selected} class-mouseover={node.hoverFeedback}
-                x={0} y={0}
+                x={0} y={0} rx={10} ry={10}
                 width={Math.max(0, node.bounds.width)} height={Math.max(0, node.bounds.height)} />
             {context.renderChildren(node)}
         </g>;

--- a/client/theia-ecore/theia-ecore/package.json
+++ b/client/theia-ecore/theia-ecore/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@theia/core": "latest",
     "sprotty-ecore": "^0.1.0",
-    "glsp-theia-extension": "latest"
+    "glsp-theia-extension": "0.1.0-next.8f55d9d9"
   },
   "devDependencies": {
     "rimraf": "latest",

--- a/client/theia-ecore/yarn.lock
+++ b/client/theia-ecore/yarn.lock
@@ -4457,17 +4457,17 @@ globby@^8.0.1:
     pify "^3.0.0"
     slash "^1.0.0"
 
-glsp-sprotty@0.4.4, glsp-sprotty@latest:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/glsp-sprotty/-/glsp-sprotty-0.4.4.tgz#4ba9ef1b91816e9b7a7b30aac834f0933193d564"
-  integrity sha512-OmMmbPyG5GjI3Ou03MMSDHmql/JwgI654wMXFCi4jB9FyjpAKxjX1igWfYuLTrP39+1SLwL4T/aGbwhTQQ6MPg==
+glsp-sprotty@0.1.0-next.8f55d9d9, glsp-sprotty@next:
+  version "0.1.0-next.8f55d9d9"
+  resolved "https://registry.yarnpkg.com/glsp-sprotty/-/glsp-sprotty-0.1.0-next.8f55d9d9.tgz#cac61e1f8d5401bd09a8cc75aaf88fc3540b447e"
+  integrity sha512-mDWWug8URzXTGxzeAyK9TmiBvsYV0IaaliK5ORX5gP6cEZ2Ws6LxPSaNo14jl1BjgRNWhAFdFeNgNlHeEUoK/A==
   dependencies:
-    sprotty latest
+    sprotty next
 
-glsp-theia-extension@latest:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/glsp-theia-extension/-/glsp-theia-extension-0.1.7.tgz#e78889d8569eada16db493189403be338f351a34"
-  integrity sha512-8jzbFKjfJeqmsy2VyG+bE/tcdUJGtY2zvo2jo5WQmsB/qKUGitEevw8MLF16Blv4CVHjI+WJ9mX6lCqAqqdaEg==
+glsp-theia-extension@0.1.0-next.8f55d9d9:
+  version "0.1.0-next.8f55d9d9"
+  resolved "https://registry.yarnpkg.com/glsp-theia-extension/-/glsp-theia-extension-0.1.0-next.8f55d9d9.tgz#70dfdadd5f21b81dabaf61e995edc25344194107"
+  integrity sha512-FjX+mcIXKQlR/eCAU5jCp2RlgH0L0gRd90uRJ7VGNaTVYUysBHP1KflXx+j3edswEy+04dgu2UZwfXYCwHibgg==
   dependencies:
     "@theia/core" latest
     "@theia/editor" latest
@@ -4475,8 +4475,8 @@ glsp-theia-extension@latest:
     "@theia/languages" latest
     "@theia/monaco" latest
     "@types/node" "^8.0.14"
-    glsp-sprotty "0.4.4"
-    theia-glsp "0.1.22"
+    glsp-sprotty next
+    theia-glsp "0.1.0-next.8f55d9d9"
 
 got@^7.0.0:
   version "7.1.0"
@@ -8438,10 +8438,10 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sprotty@latest:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/sprotty/-/sprotty-0.4.2.tgz#10d4c17932a317990f15bba25957e021218c8adb"
-  integrity sha512-G7SV8HzeT2qSpXzLTQbOVrGrlc2ZDn/6lliIu57K8+yDRCwAWtdLBWhlqu7j79msKXErOM51v3gZaNoHFBpJzA==
+sprotty@next:
+  version "0.5.0-next.3be64bd"
+  resolved "https://registry.yarnpkg.com/sprotty/-/sprotty-0.5.0-next.3be64bd.tgz#4c2a3ca05c58d85598fcd1d376918fbf44897df4"
+  integrity sha512-PWo2QeoAxk+WH6SSn05gg72h0A9ta+/yTtwmQFEGsIzu5xFOqDcp3ryAmiUoJCaCRsc8lVpD9D2efBo3xn6fOA==
   dependencies:
     file-saver "1.3.3"
     inversify "^4.3.0"
@@ -8813,17 +8813,17 @@ textextensions@2:
   resolved "https://registry.yarnpkg.com/textextensions/-/textextensions-2.2.0.tgz#38ac676151285b658654581987a0ce1a4490d286"
   integrity sha512-j5EMxnryTvKxwH2Cq+Pb43tsf6sdEgw6Pdwxk83mPaq0ToeFJt6WE4J3s5BqY7vmjlLgkgXvhtXUxo80FyBhCA==
 
-theia-glsp@0.1.22:
-  version "0.1.22"
-  resolved "https://registry.yarnpkg.com/theia-glsp/-/theia-glsp-0.1.22.tgz#616bd358007a158f1b1738f1df875baa4671db87"
-  integrity sha512-SfE33d4McDv04mRF7xQHkPkF5KU9GlmrAN4ncPsIKhwCit1PsHxl/G6CNRsVZLO8urIt/yxQHzLCV85vTDR+5w==
+theia-glsp@0.1.0-next.8f55d9d9:
+  version "0.1.0-next.8f55d9d9"
+  resolved "https://registry.yarnpkg.com/theia-glsp/-/theia-glsp-0.1.0-next.8f55d9d9.tgz#9f2d82bc0b38f5229de88498ae8b4c66a8e32b46"
+  integrity sha512-iiGfXTOducEzyZdneRK/BKlNLqq7JqMAVFu0C7PTVI5eEr6M9HJ3XcI5ekYNpN83uYX2aw1subdvtBTqciSa0g==
   dependencies:
     "@theia/core" latest
     "@theia/editor" latest
     "@theia/filesystem" latest
     "@theia/languages" latest
     "@theia/monaco" latest
-    glsp-sprotty "0.4.4"
+    sprotty next
 
 throttleit@0.0.2:
   version "0.0.2"

--- a/server/glsp-ecore/src/main/java/com/eclipsesource/glsp/ecore/model/ClassNode.java
+++ b/server/glsp-ecore/src/main/java/com/eclipsesource/glsp/ecore/model/ClassNode.java
@@ -1,20 +1,42 @@
 package com.eclipsesource.glsp.ecore.model;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import io.typefox.sprotty.api.SNode;
 
 public class ClassNode extends SNode {
+	private List<String> cssClasses;
+
+	public ClassNode() {
+		cssClasses = new ArrayList<>();
+	}
+
 	private boolean expanded;
 	private double strokeWidth;
+
 	public boolean isExpanded() {
 		return expanded;
 	}
+
 	public void setExpanded(boolean expanded) {
 		this.expanded = expanded;
 	}
+
 	public double getStrokeWidth() {
 		return strokeWidth;
 	}
+
 	public void setStrokeWidth(double strokeWidth) {
 		this.strokeWidth = strokeWidth;
 	}
+
+	public List<String> getCssClasses() {
+		return cssClasses;
+	}
+
+	public void setCssClasses(List<String> cssClasses) {
+		this.cssClasses = cssClasses;
+	}
+
 }

--- a/server/glsp-ecore/src/main/java/com/eclipsesource/glsp/ecore/model/EcoreEdge.java
+++ b/server/glsp-ecore/src/main/java/com/eclipsesource/glsp/ecore/model/EcoreEdge.java
@@ -1,11 +1,18 @@
 package com.eclipsesource.glsp.ecore.model;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import io.typefox.sprotty.api.SEdge;
 
 public class EcoreEdge extends SEdge {
+	private List<String> cssClasses;
 	private String multiplicitySource;
 	private String multiplicityTarget;
 
+	public EcoreEdge() {
+		cssClasses= new ArrayList<>();
+	}
 	public String getMultiplicitySource() {
 		return multiplicitySource;
 	}
@@ -22,4 +29,13 @@ public class EcoreEdge extends SEdge {
 		this.multiplicityTarget = multiplicityTarget;
 	}
 
+	public List<String> getCssClasses() {
+		return cssClasses;
+	}
+
+	public void setCssClasses(List<String> cssClasses) {
+		this.cssClasses = cssClasses;
+	}
+
+	
 }


### PR DESCRIPTION
Updates the CSS/Design of the Ecore Sprotty Editor to achieve a look similiar to the Sirius-based Ecore editor of Eclipse.

To make use of the latest glsp and sprotty changes the corresponding packages have been upgraded to the current stable "next" version.


![image](https://user-images.githubusercontent.com/2311075/49282645-f56f1a80-f48f-11e8-8ee0-4ee85154a1a9.png)
