### PR TITLE
Force to use specific glsp version for server component

### DIFF
--- a/server/glsp-ecore/pom.xml
+++ b/server/glsp-ecore/pom.xml
@@ -43,17 +43,15 @@
 			<artifactId>guice</artifactId>
 			<version>4.1.0</version>
 		</dependency>
-
 		<dependency>
 			<groupId>com.eclipsesource.glsp</groupId>
 			<artifactId>glsp-api</artifactId>
-			<version>0.0.1-SNAPSHOT</version>
+			<version>0.0.1-20181127.135335-15</version>
 		</dependency>
-
 		<dependency>
 			<groupId>com.eclipsesource.glsp</groupId>
 			<artifactId>glsp-server</artifactId>
-			<version>0.0.1-SNAPSHOT</version>
+			<version>0.0.1-20181127.135338-16</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>


### PR DESCRIPTION
Otherwise, the build of the server is broken as it pulls the latest glsp server, which now depends on 
 org.eclipse.sprotty rather than io.typefox.sprotty. Therefore, we'd first have to explicitly migrate to the new GLSP version.