### PR TITLE
[36] Distinguish label node edition vs main label edition

### DIFF
--- a/server/src/main/java/com/eclipsesource/glsp/ecore/gmodel/LabelFactory.java
+++ b/server/src/main/java/com/eclipsesource/glsp/ecore/gmodel/LabelFactory.java
@@ -1,4 +1,3 @@
-
 /********************************************************************************
  * Copyright (c) 2019 EclipseSource and others.
  *
@@ -42,7 +41,7 @@ public class LabelFactory extends AbstractGModelFactory<ENamedElement, GLabel> {
 	}
 
 	public GLabel create(EAttribute eAttribute) {
-		String label = String.format(" %s : %s", eAttribute.getName(), //
+		String label = String.format("%s : %s", eAttribute.getName(), //
 				eAttribute.getEAttributeType().getName());
 		return new GLabelBuilder(Types.ATTRIBUTE) //
 				.id(toId(eAttribute))//


### PR DESCRIPTION
- We now have two distinct cases: editing List Items (The label represents a model element) vs editing the Label of a Node (The label represents a feature of a model element)
- Minor code clean-up

In the original version, I was especially confused by this line:

> shape.setSemanticElement(facade.createProxy(callingObject.get()));

Where shape represents the EAttribute's parent EClass and callingObject represents the EAttribute itself. It turns out that, since EAttributes aren't associated to a Notation element, we don't need that line there. I've restructured the code a bit to clearly distinguish the two cases