### PR TITLE
Specify a targetAnchorCorrection Value for ArrowEdges

### DIFF
--- a/client/sprotty-ecore/src/di.config.ts
+++ b/client/sprotty-ecore/src/di.config.ts
@@ -70,7 +70,7 @@ import executeCommandModule from "@glsp/sprotty-client/lib/features/execute/di.c
 import { Container, ContainerModule } from "inversify";
 
 import { LabelSelectionFeedback } from "./feedback";
-import {ArrowEdge, Icon, LabeledNode, SEditableLabel, SLabelNode} from "./model";
+import {ArrowEdge, CompositionEdge, Icon, InheritanceEdge, LabeledNode, SEditableLabel, SLabelNode} from "./model";
 import { ArrowEdgeView, ClassNodeView, CompositionEdgeView, IconView, InheritanceEdgeView, LabelNodeView } from "./views";
 
 export default (containerId: string) => {
@@ -97,8 +97,8 @@ export default (containerId: string) => {
         configureModelElement(context, 'routing-point', SRoutingHandle, SRoutingHandleView);
         configureModelElement(context, 'volatile-routing-point', SRoutingHandle, SRoutingHandleView);
         configureModelElement(context, 'edge:reference', ArrowEdge, ArrowEdgeView);
-        configureModelElement(context, 'edge:inheritance', SEdge, InheritanceEdgeView);
-        configureModelElement(context, 'edge:composition', SEdge, CompositionEdgeView);
+        configureModelElement(context, 'edge:inheritance', InheritanceEdge, InheritanceEdgeView);
+        configureModelElement(context, 'edge:composition', CompositionEdge, CompositionEdgeView);
         configureModelElement(context, 'edge', SEdge, PolylineEdgeView);
         configureViewerOptions(context, {
             needsClientLayout: true,

--- a/client/sprotty-ecore/src/di.config.ts
+++ b/client/sprotty-ecore/src/di.config.ts
@@ -70,7 +70,7 @@ import executeCommandModule from "@glsp/sprotty-client/lib/features/execute/di.c
 import { Container, ContainerModule } from "inversify";
 
 import { LabelSelectionFeedback } from "./feedback";
-import { Icon, LabeledNode, SEditableLabel, SLabelNode } from "./model";
+import {ArrowEdge, Icon, LabeledNode, SEditableLabel, SLabelNode} from "./model";
 import { ArrowEdgeView, ClassNodeView, CompositionEdgeView, IconView, InheritanceEdgeView, LabelNodeView } from "./views";
 
 export default (containerId: string) => {
@@ -96,7 +96,7 @@ export default (containerId: string) => {
         configureModelElement(context, 'html', HtmlRoot, HtmlRootView);
         configureModelElement(context, 'routing-point', SRoutingHandle, SRoutingHandleView);
         configureModelElement(context, 'volatile-routing-point', SRoutingHandle, SRoutingHandleView);
-        configureModelElement(context, 'edge:reference', SEdge, ArrowEdgeView);
+        configureModelElement(context, 'edge:reference', ArrowEdge, ArrowEdgeView);
         configureModelElement(context, 'edge:inheritance', SEdge, InheritanceEdgeView);
         configureModelElement(context, 'edge:composition', SEdge, CompositionEdgeView);
         configureModelElement(context, 'edge', SEdge, PolylineEdgeView);

--- a/client/sprotty-ecore/src/model.ts
+++ b/client/sprotty-ecore/src/model.ts
@@ -89,3 +89,11 @@ export class SLabelNode extends SLabel implements EditableLabel {
 export class ArrowEdge extends SEdge {
     public readonly targetAnchorCorrection = 3.3;
 }
+
+export class CompositionEdge extends SEdge {
+    public readonly sourceAnchorCorrection = 3.0;
+}
+
+export class InheritanceEdge extends SEdge {
+    public readonly targetAnchorCorrection = 2.3;
+}

--- a/client/sprotty-ecore/src/model.ts
+++ b/client/sprotty-ecore/src/model.ts
@@ -31,7 +31,8 @@ import {
     SLabel,
     SShapeElement,
     WithEditableLabel,
-    withEditLabelFeature
+    withEditLabelFeature,
+    SEdge
 } from "sprotty/lib";
 
 
@@ -83,4 +84,8 @@ export class SLabelNode extends SLabel implements EditableLabel {
     hasFeature(feature: symbol): boolean {
         return (feature === selectFeature || feature === editLabelFeature || feature === popupFeature || feature === deletableFeature || feature === hoverFeedbackFeature || super.hasFeature(feature));
     }
+}
+
+export class ArrowEdge extends SEdge {
+    public readonly targetAnchorCorrection = 3.3;
 }

--- a/client/sprotty-ecore/src/views.tsx
+++ b/client/sprotty-ecore/src/views.tsx
@@ -70,12 +70,6 @@ export class ArrowEdgeView extends PolylineEdgeView {
     ];
   }
 
-  static readonly TARGET_CORRECTION = Math.sqrt(1 * 1 + 2.5 * 2.5);
-
-  protected getTargetAnchorCorrection(edge: SEdge): number {
-    return ArrowEdgeView.TARGET_CORRECTION;
-  }
-
 }
 
 @injectable()
@@ -87,12 +81,6 @@ export class InheritanceEdgeView extends ArrowEdgeView {
       <path class-sprotty-edge={true} class-triangle={true} d="M 10,-8 L 0,0 L 10,8 Z" class-inheritance={true}
         transform={`rotate(${angle(p2, p1)} ${p2.x} ${p2.y}) translate(${p2.x} ${p2.y})`} />,
     ];
-  }
-
-  static readonly TARGET_CORRECTION = Math.sqrt(1 * 1 + 2.5 * 2.5);
-
-  protected getTargetAnchorCorrection(edge: SEdge): number {
-    return ArrowEdgeView.TARGET_CORRECTION;
   }
 }
 
@@ -108,12 +96,6 @@ abstract class DiamondEdgeView extends PolylineEdgeView {
       <path class-sprotty-edge={true} class-diamond={true} class-composition={this.isComposition()} d={rhombStr}
         transform={`rotate(${firstEdgeAngle} ${p1.x} ${p1.y}) translate(${p1.x} ${p1.y})`} />
     ];
-  }
-
-  static readonly SOURCE_CORRECTION = Math.sqrt(1 * 1 + 2 * 2);
-
-  protected getSourceAnchorCorrection(edge: SEdge): number {
-    return CompositionEdgeView.SOURCE_CORRECTION;
   }
   protected isComposition(): boolean {
     return false;


### PR DESCRIPTION
A correction of 3.3 leaves a very small distance between the arrow in the class, but with this value the arrow reaches not to far over the border of the class on hovering (as with 3.0).

In the following I give some example value - if you do not like the current configuration you may choose different ones:

### Correction 3.3
![image](https://user-images.githubusercontent.com/17315614/69480956-ddb14480-0e0c-11ea-99b9-a7eefbc73142.png)
![image](https://user-images.githubusercontent.com/17315614/69480966-f91c4f80-0e0c-11ea-9295-80fef518b7cf.png)

### Correction 3.5 - does not reach over at all but a slight distance is visible 
![image](https://user-images.githubusercontent.com/17315614/69480989-3da7eb00-0e0d-11ea-82cd-203e8d7d046c.png)
![image](https://user-images.githubusercontent.com/17315614/69481002-51535180-0e0d-11ea-97cf-424ff5e163bd.png)

### Correction 3.0 - does reach over - no distance
![image](https://user-images.githubusercontent.com/17315614/69481033-ab541700-0e0d-11ea-9afd-646fa0bc0bf2.png)
![image](https://user-images.githubusercontent.com/17315614/69481038-c2930480-0e0d-11ea-87d7-903ca374553a.png)


Resolves #57 