### PR TITLE
Dark Theme Improvements

### DIFF
--- a/client/sprotty-ecore/css/diagram.css
+++ b/client/sprotty-ecore/css/diagram.css
@@ -1,10 +1,21 @@
+:root {
+    --sprotty-background: var(--theia-layout-color3);
+    --sprotty-edge: var(--theia-ui-font-color1);
+    --sprotty-border: var(--theia-border-color2);
+}
+
 svg {
     margin-top: 15px;
     width: 100%;
     height: 500px;
     border-style: solid;
     border-width: 1px;
-    border-color: #bbb;
+    border-color: var(--sprotty-border);
+}
+
+.label-edit input {
+    background: rgba(255, 255, 255, 0.5);
+    color: black;
 }
 
 .sprotty {
@@ -14,7 +25,7 @@ svg {
 .sprotty-graph {
     font-size: 15pt;
     height: 100%;
-    background: #fff
+    background: var(--sprotty-background);
 }
 
 .ecore-node {
@@ -94,8 +105,16 @@ svg {
 
 .ecore-edge {
     fill: none;
-    stroke: black;
+    stroke: var(--sprotty-edge);
     stroke-width: 2px;
+}
+
+.ecore-edge>.sprotty-label {
+    stroke-width: 0;
+    width: inherit;
+    fill: var(--sprotty-edge);
+    font-weight: inherit;
+    font-size: 100%;
 }
 
 .feedback-edge {
@@ -146,23 +165,19 @@ svg {
 }
 
 .ecore-edge>.triangle.inheritance {
-    fill: white;
-}
-
-.ecore-edge.inheritance {
-    stroke: #888888;
+    fill: var(--sprotty-background);
 }
 
 .ecore-edge.aggregation .ecore-edge.composition {
-    stroke: black;
+    stroke: var(--sprotty-edge);
 }
 
 .ecore-edge>.diamond.aggregation {
-    fill: white;
+    fill: var(--sprotty-background);
 }
 
 .ecore-edge>.diamond.composition {
-    fill: black;
+    fill: var(--sprotty-edge);
 }
 
 .ecore-edge.selected {


### PR DESCRIPTION
Dark theme is now supported by the diagram editor and the InputField for renaming Attributes/Classes is now better readable in both Themes.
Light Theme, does not have a white background anymore, due to the way the theme colors in theia work. A follow-up issue will be submitted (#70).
Inheritance edges now have the same color as other edges.

New Light Theme:
![LightTheme](https://user-images.githubusercontent.com/51790726/69541804-58539e80-0f8a-11ea-8447-38a4d722e311.PNG)

New Dark Theme:
![DarkTheme](https://user-images.githubusercontent.com/51790726/69541810-60134300-0f8a-11ea-9b5b-60cce1f2bfa5.PNG)

Renaming looks the following in Dark Theme:
![Renaming2](https://user-images.githubusercontent.com/51790726/69541831-6bff0500-0f8a-11ea-8f15-7f3983ba2598.PNG)


Resolves Issue #51