### PR TITLE
Enable EDataTypes

### DIFF
--- a/client/sprotty-ecore/src/di.config.ts
+++ b/client/sprotty-ecore/src/di.config.ts
@@ -71,7 +71,21 @@ import { Container, ContainerModule } from "inversify";
 import {EditLabelUIAutocomplete} from "./features/edit-label-autocomplete";
 import { EditLabelUI } from "sprotty/lib";
 import { LabelSelectionFeedback } from "./feedback";
-import {ArrowEdge, CompositionEdge, InheritanceEdge, LabeledNode, SEditableLabel, IconDataType, IconEnum, IconInterface, IconAbstract, IconClass, SLabelNodeAttribute, SLabelNodeLiteral} from "./model";
+import {
+    ArrowEdge,
+    CompositionEdge,
+    InheritanceEdge,
+    LabeledNode,
+    SEditableLabel,
+    IconDataType,
+    IconEnum,
+    IconInterface,
+    IconAbstract,
+    IconClass,
+    SLabelNodeAttribute,
+    SLabelNodeLiteral,
+    SLabelNode
+} from "./model";
 import { ArrowEdgeView, ClassNodeView, CompositionEdgeView, IconView, InheritanceEdgeView, LabelNodeView } from "./views";
 
 export default (containerId: string) => {
@@ -89,6 +103,7 @@ export default (containerId: string) => {
         configureModelElement(context, 'label:name', SEditableLabel, SLabelView);
         configureModelElement(context, 'label:edge-name', SEditableLabel, SLabelView);
         configureModelElement(context, 'label:edge-multiplicity', SEditableLabel, SLabelView);
+        configureModelElement(context, 'label:instancename', SLabelNode, LabelNodeView);
         configureModelElement(context, 'node:attribute', SLabelNodeAttribute, LabelNodeView);
         configureModelElement(context, 'node:enumliteral', SLabelNodeLiteral, LabelNodeView);
         configureModelElement(context, 'node:operation', SNode, RectangularNodeView);

--- a/client/sprotty-ecore/src/views.tsx
+++ b/client/sprotty-ecore/src/views.tsx
@@ -131,7 +131,10 @@ export class AggregationEdgeView extends DiamondEdgeView {
 @injectable()
 export class LabelNodeView extends SLabelView {
   render(labelNode: Readonly<SLabelNode>, context: RenderingContext): VNode {
-    const image = require("../images/" + labelNode.imageName);
+      let image;
+      if (labelNode.imageName) {
+          image = require("../images/" + labelNode.imageName);
+      }
 
     const vnode = (
       <g
@@ -139,8 +142,8 @@ export class LabelNodeView extends SLabelView {
         class-mouseover={labelNode.hoverFeedback}
         class-sprotty-label-node={true}
       >
-        <image class-sprotty-icon={true} href={image} y={-4} width={13} height={8}></image>
-        <text class-sprotty-label={true} x={20}>{labelNode.text}</text>
+          { !!image && <image class-sprotty-icon={true} href={image} y={-4} width={13} height={8}></image> }
+        <text class-sprotty-label={true} x={!!image ? 20 : 0}>{labelNode.text}</text>
       </g>
     );
 

--- a/server/ecore-glsp/src/main/java/com/eclipsesource/glsp/ecore/EcoreDiagramConfiguration.java
+++ b/server/ecore-glsp/src/main/java/com/eclipsesource/glsp/ecore/EcoreDiagramConfiguration.java
@@ -54,7 +54,7 @@ public class EcoreDiagramConfiguration implements DiagramConfiguration {
 	public List<ShapeTypeHint> getNodeTypeHints() {
 		List<ShapeTypeHint> hints = new ArrayList<>();
 		hints.add(new ShapeTypeHint(DefaultTypes.GRAPH, false, false, false, false,
-				List.of(Types.ECLASS, Types.ABSTRACT, Types.INTERFACE, Types.ENUM)));
+				List.of(Types.ECLASS, Types.ABSTRACT, Types.INTERFACE, Types.ENUM, Types.DATATYPE)));
 		hints.add(new ShapeTypeHint(Types.ECLASS, true, true, false, false, List.of(Types.ATTRIBUTE, Types.OPERATION)));
 		hints.add(new ShapeTypeHint(Types.ENUM, true, true, false, false, List.of(Types.ENUMLITERAL)));
 		hints.add(new ShapeTypeHint(Types.DATATYPE, true, true, false, true));
@@ -120,6 +120,7 @@ public class EcoreDiagramConfiguration implements DiagramConfiguration {
 		mappings.put(Types.ATTRIBUTE, GraphPackage.Literals.GLABEL);
 		mappings.put(Types.OPERATION, GraphPackage.Literals.GLABEL);
 		mappings.put(Types.ENUMLITERAL, GraphPackage.Literals.GLABEL);
+		mappings.put(Types.LABEL_INSTANCE, GraphPackage.Literals.GLABEL);
 		return mappings;
 	}
 

--- a/server/ecore-glsp/src/main/java/com/eclipsesource/glsp/ecore/gmodel/ClassifierNodeFactory.java
+++ b/server/ecore-glsp/src/main/java/com/eclipsesource/glsp/ecore/gmodel/ClassifierNodeFactory.java
@@ -102,8 +102,9 @@ public class ClassifierNodeFactory extends AbstractGModelFactory<EClassifier, GN
 								.hAlign(GConstants.HAlign.CENTER) //
 								.resizeContainer(true) //
 								.build()) //
-						.add(new GLabelBuilder(Types.LABEL_TEXT) //
-								.addCssClass(CSS.ITALIC).id(toId(eDataType) + "_typeLabel")//
+						.add(new GLabelBuilder(Types.LABEL_INSTANCE) //
+								.addCssClass(CSS.ITALIC)//
+								.id(toId(eDataType) + Types.LABEL_INSTANCE)//
 								.text(eDataType.getInstanceClassName()) //
 								.build())
 						.build());

--- a/server/ecore-glsp/src/main/java/com/eclipsesource/glsp/ecore/operationhandler/EcoreLabelEditOperationHandler.java
+++ b/server/ecore-glsp/src/main/java/com/eclipsesource/glsp/ecore/operationhandler/EcoreLabelEditOperationHandler.java
@@ -61,7 +61,6 @@ public class EcoreLabelEditOperationHandler implements OperationHandler {
 		ApplyLabelEditOperationAction editLabelAction = (ApplyLabelEditOperationAction) action;
 		EcoreFacade facade = EcoreModelState.getEcoreFacade(graphicalModelState);
 		EcoreModelIndex index = EcoreModelState.getModelState(graphicalModelState).getIndex();
-
 		Optional<String> type = index.findElementByClass(editLabelAction.getLabelId(), GModelElement.class).map(e -> e.getType());
 		if (type.isPresent()) {
 			switch (type.get()) {
@@ -81,7 +80,16 @@ public class EcoreLabelEditOperationHandler implements OperationHandler {
 							shape.setSemanticElement(facade.createProxy(node_semantic));
 						}
 					break;
+				case Types.LABEL_INSTANCE:
+					node = getOrThrow(index.findElementByClass(editLabelAction.getLabelId(), GNode.class), 
+							"No parent Node for element with id " + editLabelAction.getLabelId() + " found");
 
+					node_semantic = getOrThrow(index.getSemantic(node),
+							"No semantic element for labelContainer with id " + node.getId() + " found");
+					if (node_semantic instanceof EClassifier) {
+						((EClassifier) node_semantic).setInstanceClassName(editLabelAction.getText().trim());
+					}
+					break;
 				case Types.ATTRIBUTE:
 					EAttribute attribute_semantic = (EAttribute) getOrThrow(index.getSemantic(editLabelAction.getLabelId()),
 						"No semantic element for label with id " + editLabelAction.getLabelId() + " found");
@@ -138,7 +146,6 @@ public class EcoreLabelEditOperationHandler implements OperationHandler {
 							throw new GLSPServerException("Multiplicity of reference with id " + editLabelAction.getLabelId() + " has a wrong input format", new IllegalArgumentException());
 						}
 					break;
-
 			}
 		}
 	}

--- a/server/ecore-glsp/src/main/java/com/eclipsesource/glsp/ecore/util/EcoreConfig.java
+++ b/server/ecore-glsp/src/main/java/com/eclipsesource/glsp/ecore/util/EcoreConfig.java
@@ -42,6 +42,7 @@ public final class EcoreConfig {
 		public static final String INHERITANCE = "edge:inheritance";
 		public static final String ABSTRACT = "node:class:abstract";
 		public static final String INTERFACE = "node:class:interface";
+		public static final String LABEL_INSTANCE = "label:instancename";
 
 		private Types() {
 		};


### PR DESCRIPTION
Allows Editing of EDataTypes again.

~~This is currently for discussion: Please have a look regarding editing of the instanceType and how to handle wrong classnames on GLSP-Server.~~

See also [this discussion](https://spectrum.chat/emfcloud/general/datatypes-subtype~91c3857f-c3e6-4811-a5fa-6409b71e6fa9)

Resolves #81 
Resolves https://github.com/jonny3576/ecore-glsp/issues/19