### PR TITLE
33: Add an Eclipse Product with EMF Codegen applications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
 *.iml
-server/ecore-backend-server/target/
-server/target/
+target/
+target/
+bin/

--- a/server/backend-app/.project
+++ b/server/backend-app/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>backend-app</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/server/backend-app/README.md
+++ b/server/backend-app/README.md
@@ -1,0 +1,3 @@
+# Ecore GLSP Backend App
+
+This folder contains the Eclipse Plug-ins for the Ecore GLSP Backend product. It provides an entry point for all Eclipse Applications involved in the Ecore GLSP Backend (GenModel creation, Code generation...)

--- a/server/backend-app/ecore.glsp.backend.app/.classpath
+++ b/server/backend-app/ecore.glsp.backend.app/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/server/backend-app/ecore.glsp.backend.app/.project
+++ b/server/backend-app/ecore.glsp.backend.app/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>ecore.glsp.backend.app</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/server/backend-app/ecore.glsp.backend.app/.settings/org.eclipse.jdt.core.prefs
+++ b/server/backend-app/ecore.glsp.backend.app/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=11

--- a/server/backend-app/ecore.glsp.backend.app/META-INF/MANIFEST.MF
+++ b/server/backend-app/ecore.glsp.backend.app/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Ecore GLSP Backend
+Bundle-SymbolicName: ecore.glsp.backend.app;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Automatic-Module-Name: ecore.glsp.backend.app
+Bundle-RequiredExecutionEnvironment: JavaSE-11
+Require-Bundle: org.eclipse.equinox.app

--- a/server/backend-app/ecore.glsp.backend.app/build.properties
+++ b/server/backend-app/ecore.glsp.backend.app/build.properties
@@ -1,0 +1,5 @@
+output.. = bin/
+bin.includes = META-INF/,\
+               .,\
+               plugin.xml
+source.. = src/

--- a/server/backend-app/ecore.glsp.backend.app/plugin.xml
+++ b/server/backend-app/ecore.glsp.backend.app/plugin.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         id="product"
+         point="org.eclipse.core.runtime.products">
+      <product
+            application="org.eclipse.emf.codegen.CodeGen"
+            name="Ecore GLSP Backend">
+         <property
+               name="appName"
+               value="Ecore GLSP Backend">
+         </property>
+      </product>
+   </extension>
+
+</plugin>

--- a/server/backend-app/ecore.glsp.backend.app/pom.xml
+++ b/server/backend-app/ecore.glsp.backend.app/pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.eclipsesource.glsp</groupId>
+		<artifactId>ecore-backend-apps</artifactId>
+		<version>1.0.0</version>
+	</parent>
+
+	<artifactId>ecore.glsp.backend.app</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>eclipse-plugin</packaging>
+
+</project>

--- a/server/backend-app/ecore.glsp.codegen.feature/.project
+++ b/server/backend-app/ecore.glsp.codegen.feature/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>ecore.glsp.codegen.feature</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.FeatureBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+	</natures>
+</projectDescription>

--- a/server/backend-app/ecore.glsp.codegen.feature/build.properties
+++ b/server/backend-app/ecore.glsp.codegen.feature/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/server/backend-app/ecore.glsp.codegen.feature/feature.xml
+++ b/server/backend-app/ecore.glsp.codegen.feature/feature.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="ecore.glsp.codegen.feature"
+      label="Ecore GLSP Codegen"
+      version="1.0.0.qualifier">
+
+   <description url="http://www.example.com/description">
+      [Enter Feature Description here.]
+   </description>
+
+   <copyright url="http://www.example.com/copyright">
+      [Enter Copyright Description here.]
+   </copyright>
+
+   <license url="http://www.example.com/license">
+      [Enter License Description here.]
+   </license>
+
+   <includes
+         id="org.eclipse.emf.common"
+         version="0.0.0"/>
+
+   <includes
+         id="org.eclipse.emf.ecore"
+         version="0.0.0"/>
+
+   <includes
+         id="org.eclipse.emf.codegen.ecore"
+         version="0.0.0"/>
+
+   <includes
+         id="org.eclipse.core.runtime.feature"
+         version="0.0.0"/>
+
+   <includes
+         id="org.eclipse.emf.codegen"
+         version="0.0.0"/>
+
+   <requires>
+      <import plugin="org.eclipse.equinox.app"/>
+   </requires>
+
+   <plugin
+         id="ecore.glsp.backend.app"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.jdt.core"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.jdt.launching"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.core.resources"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.core.filesystem"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.ant"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.ant.core"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.debug.core"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.text"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.core.commands"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.jdt.debug"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"/>
+
+   <plugin
+         id="com.ibm.icu"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>

--- a/server/backend-app/ecore.glsp.codegen.feature/pom.xml
+++ b/server/backend-app/ecore.glsp.codegen.feature/pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.eclipsesource.glsp</groupId>
+		<artifactId>ecore-backend-apps</artifactId>
+		<version>1.0.0</version>
+	</parent>
+
+	<artifactId>ecore.glsp.codegen.feature</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>eclipse-feature</packaging>
+
+</project>

--- a/server/backend-app/ecore.glsp.codegen.product/.project
+++ b/server/backend-app/ecore.glsp.codegen.product/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>ecore.glsp.codegen.product</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/server/backend-app/ecore.glsp.codegen.product/ecore.glsp.codegen.product
+++ b/server/backend-app/ecore.glsp.codegen.product/ecore.glsp.codegen.product
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?pde version="3.5"?>
+
+<product name="Ecore GLSP Backend" uid="ecore.glsp.codegen" id="ecore.glsp.backend.app.product" application="org.eclipse.emf.codegen.CodeGen" version="1.0.0" useFeatures="true" includeLaunchers="true">
+
+
+   <configIni use="default">
+   </configIni>
+
+   <launcherArgs>
+      <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
+      </vmArgsMac>
+   </launcherArgs>
+
+   <windowImages/>
+
+
+   <launcher name="ecore_glsp_backend">
+      <win useIco="false">
+         <bmp/>
+      </win>
+   </launcher>
+
+
+   <vm>
+   </vm>
+
+
+   <plugins>
+   </plugins>
+
+   <features>
+      <feature id="ecore.glsp.codegen.feature"/>
+   </features>
+
+   <configurations>
+      <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="0" />
+      <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.equinox.ds" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
+      <plugin id="org.eclipse.osgi" autoStart="true" startLevel="-1" />
+   </configurations>
+
+   <preferencesInfo>
+      <targetfile overwrite="false"/>
+   </preferencesInfo>
+
+   <cssInfo>
+   </cssInfo>
+
+</product>

--- a/server/backend-app/ecore.glsp.codegen.product/pom.xml
+++ b/server/backend-app/ecore.glsp.codegen.product/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.eclipsesource.glsp</groupId>
+		<artifactId>ecore-backend-apps</artifactId>
+		<version>1.0.0</version>
+	</parent>
+
+	<artifactId>ecore.glsp.codegen.product</artifactId>
+	<version>1.0.0</version>
+	<packaging>eclipse-repository</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-director-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<executions>
+					<execution>
+						<id>materialize-products</id>
+						<goals>
+							<goal>materialize-products</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/server/backend-app/pom.xml
+++ b/server/backend-app/pom.xml
@@ -1,0 +1,64 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.eclipsesource.glsp</groupId>
+	<artifactId>ecore-backend-apps</artifactId>
+	<packaging>pom</packaging>
+	<version>1.0.0</version>
+
+	<properties>
+		<tycho-version>1.6.0</tycho-version>
+	</properties>
+
+	<modules>
+		<module>targetplatform</module>
+		<module>ecore.glsp.backend.app</module>
+		<module>ecore.glsp.codegen.product</module>
+		<module>ecore.glsp.codegen.feature</module>
+	</modules>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<target>
+						<artifact>
+							<groupId>com.eclipsesource.glsp</groupId>
+							<artifactId>targetplatform</artifactId>
+							<version>1.0</version>
+						</artifact>
+					</target>
+					<environments>
+						<environment>
+							<os>linux</os>
+							<ws>gtk</ws>
+							<arch>x86_64</arch>
+						</environment>
+						<environment>
+							<os>win32</os>
+							<ws>win32</ws>
+							<arch>x86_64</arch>
+						</environment>
+						<environment>
+							<os>macosx</os>
+							<ws>cocoa</ws>
+							<arch>x86_64</arch>
+						</environment>
+					</environments>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/server/backend-app/targetplatform/.project
+++ b/server/backend-app/targetplatform/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>targetplatform</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/server/backend-app/targetplatform/pom.xml
+++ b/server/backend-app/targetplatform/pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.eclipsesource.glsp</groupId>
+		<artifactId>ecore-backend-apps</artifactId>
+		<version>1.0.0</version>
+	</parent>
+
+	<artifactId>targetplatform</artifactId>
+	<version>1.0</version>
+	<packaging>eclipse-target-definition</packaging>
+
+</project>

--- a/server/backend-app/targetplatform/targetplatform.target
+++ b/server/backend-app/targetplatform/targetplatform.target
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde?>
+<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
+<target name="Ecore GLSP Codegen" sequenceNumber="1582722292">
+  <locations>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.emf.ecore.feature.group" version="2.20.0.v20190920-0401"/>
+      <unit id="org.eclipse.emf.common.feature.group" version="2.17.0.v20190920-0401"/>
+      <unit id="org.eclipse.emf.codegen.ecore.feature.group" version="2.20.0.v20191012-0918"/>
+      <unit id="org.eclipse.core.runtime.feature.feature.group" version="1.2.700.v20191122-2104"/>
+      <unit id="org.eclipse.emf.codegen.feature.group" version="2.19.0.v20190821-1536"/>
+      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.600.v20191014-2025"/>
+      <repository location="http://download.eclipse.org/releases/2019-12"/>
+    </location>
+  </locations>
+</target>

--- a/server/backend-app/targetplatform/targetplatform.tpd
+++ b/server/backend-app/targetplatform/targetplatform.tpd
@@ -1,0 +1,10 @@
+target "Ecore GLSP Codegen" with requirements source 
+
+location "http://download.eclipse.org/releases/2019-12" {
+	org.eclipse.emf.ecore.feature.group [2.20.0,3.0.0)
+	org.eclipse.emf.common.feature.group [2.17.0,3.0.0)
+	org.eclipse.emf.codegen.ecore.feature.group [2.20.0,3.0.0)
+	org.eclipse.core.runtime.feature.feature.group [1.2.700,2.0.0)
+	org.eclipse.emf.codegen.feature.group [2.19.0,3.0.0)
+	org.eclipse.equinox.executable.feature.group [3.8.600,4.0.0)
+}

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -13,5 +13,6 @@
     <modules>
         <module>ecore-backend-server</module>
         <module>ecore-glsp</module>
+        <module>backend-app</module>
     </modules>
 </project>


### PR DESCRIPTION
The PR provides the sources to build a minimal Eclipse Product that includes the required EMF Codegen plug-ins. We should consider including the current & wip applications in this product (e.g. the current ecore-backend-server, as well as the wip GenModel creation & Code Generation).

- The product can be built and then used in the Ecore GLSP Theia Backend to trigger Genmodel creation & code generation