### PR TITLE
Change alignment-baseline to dominant-baseline

### DIFF
--- a/client/sprotty-ecore/css/diagram.css
+++ b/client/sprotty-ecore/css/diagram.css
@@ -51,7 +51,7 @@ svg {
 }
 
 .sprotty-label-node>.sprotty-label {
-    alignment-baseline: middle;	
+    dominant-baseline: middle;
 }
 
 .sprotty-label-node>.selection-feedback {

--- a/client/sprotty-ecore/src/views.tsx
+++ b/client/sprotty-ecore/src/views.tsx
@@ -153,7 +153,7 @@ export class LabelNodeView extends SLabelView {
         class-mouseover={labelNode.hoverFeedback}
         class-sprotty-label-node={true}
       >
-          { !!image && <image class-sprotty-icon={true} href={image} y={-4} width={13} height={8}></image> }
+          { !!image && <image class-sprotty-icon={true} href={image} y={-5} width={13} height={8}></image> }
         <text class-sprotty-label={true} x={!!image ? 20 : 0}>{labelNode.text}</text>
       </g>
     );


### PR DESCRIPTION
Changed to dominant-baseline for firefox support. Also moved up the icon a bit so it is more centered.

Resolves #94.

Signed-off-by: Simon Graband <simon.graband@tum.de>