### PR TITLE
[71] [104] Dangling HREF on save

### DIFF
--- a/server/org.eclipse.emfcloud.ecore.glsp/src/main/java/org/eclipse/emfcloud/ecore/glsp/EcoreServerLauncher.java
+++ b/server/org.eclipse.emfcloud.ecore.glsp/src/main/java/org/eclipse/emfcloud/ecore/glsp/EcoreServerLauncher.java
@@ -21,6 +21,10 @@ import org.eclipse.glsp.server.launch.GLSPServerLauncher;
 
 public class EcoreServerLauncher {
 
+	private static final Logger LOG = Logger.getLogger(EcoreServerLauncher.class);
+	
+	private static final int DEFAULT_PORT = 5007;
+	
 	public static void main(String[] args) {
 		int port = getPort(args);
 		
@@ -39,6 +43,7 @@ public class EcoreServerLauncher {
 				return Integer.parseInt(args[i+1]);
 			}
 		}
-		throw new IllegalArgumentException("No port is defined for ECORE-GLSP. Specify a port as a command line argument with '--port <portnumber>'");
+		LOG.info("The server port was not specified; using default port 5007");
+		return DEFAULT_PORT;
 	}
 }

--- a/server/org.eclipse.emfcloud.ecore.glsp/src/main/java/org/eclipse/emfcloud/ecore/glsp/ResourceManager.java
+++ b/server/org.eclipse.emfcloud.ecore.glsp/src/main/java/org/eclipse/emfcloud/ecore/glsp/ResourceManager.java
@@ -134,12 +134,13 @@ public class ResourceManager {
 			return;
 		}
 		
-		System.err.println("Some errors have been found while saving "+resource.getURI().lastSegment()+":");
+		LOG.error("Some errors have been found while saving "+resource.getURI().lastSegment()+":");
 		for (Diagnostic d : resource.getErrors()) {
 			if (d instanceof Exception) {
-				((Exception) d).printStackTrace();
+				LOG.error(d.getMessage(), (Exception) d);
 			}
 		}
+	
 	}
 
 }


### PR DESCRIPTION
The first commit improves the robustness of save against dangling hrefs (Log rather than throw & corrupt the model)

The second commit improves the delete action to avoid leaving dangling hrefs. Note that it wasn't sufficient to just call EcoreUtil::delete in this case, because untyped EReferences are currently not well handled and caused unrecoverable errors on the client side; so I currently delete all EAttributes/EReferences typed with the deleted classifiers (It really makes sense for EReferences, since the edge is deleted as well; for EAttributes it's a bit weirder, as seemingly unrelated EAttributes might disappear when deleting an EDataType or EEnum)

This fixes both #71 and #104 